### PR TITLE
use registry input in image tags

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.go]
+indent_style = tab

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ For example:
     repository: jerray/publish-docker-action
 ```
 
+This will build and push the tag `docker.pkg.github.com/jerray/publish-docker-action:latest`.
+
 ### Tags
 
 #### Static Tag List
@@ -54,9 +56,9 @@ You can use static tag list by providing `tags` argument. Concat multiple tag na
 
 This example builds the image, creates three tags, and pushes all of them to the registry.
 
-* `jerray/publish-docker-action:latest`
-* `jerray/publish-docker-action:newest`
-* `jerray/publish-docker-action:master`
+* `docker.pkg.github.com/jerray/publish-docker-action:latest`
+* `docker.pkg.github.com/jerray/publish-docker-action:newest`
+* `docker.pkg.github.com/jerray/publish-docker-action:master`
 
 #### Auto Tag
 

--- a/helper.go
+++ b/helper.go
@@ -17,6 +17,10 @@ func resolveInputs(github GitHub, inputs *Inputs) error {
 		inputs.Repository = github.Repository
 	}
 
+	if inputs.Registry != "" && !strings.HasPrefix(inputs.Repository, inputs.Registry) {
+		inputs.Repository = strings.Join([]string{inputs.Registry, inputs.Repository}, "/")
+	}
+
 	typ, name := resolveRef(github)
 
 	if typ == RefTypePull && !inputs.AllowPullRequest {

--- a/helper_test.go
+++ b/helper_test.go
@@ -44,6 +44,35 @@ func Test_resolveInputs(t *testing.T) {
 			github: GitHub{
 				Repository: "username/repo",
 				Commit:     "45ba489c4f97b5f854ebaba6454b51fa",
+				Ref:        "refs/heads/master",
+			},
+			inputs: &Inputs{
+				Registry: "other.docker.io",
+				Tags:     []string{"my_tag"},
+			},
+			hasError:   false,
+			tags:       []string{"other.docker.io/username/repo:my_tag"},
+			repository: "other.docker.io/username/repo",
+		},
+		{
+			github: GitHub{
+				Repository: "username/repo",
+				Commit:     "45ba489c4f97b5f854ebaba6454b51fa",
+				Ref:        "refs/heads/master",
+			},
+			inputs: &Inputs{
+				Registry:   "other.docker.io",
+				Repository: "other.docker.io/my/repo",
+				Tags:       []string{"my_tag"},
+			},
+			hasError:   false,
+			tags:       []string{"other.docker.io/my/repo:my_tag"},
+			repository: "other.docker.io/my/repo",
+		},
+		{
+			github: GitHub{
+				Repository: "username/repo",
+				Commit:     "45ba489c4f97b5f854ebaba6454b51fa",
 				Ref:        "refs/pull/master",
 			},
 			inputs: &Inputs{


### PR DESCRIPTION
It seems that the `registry` input wasn't actually being used anywhere, so I added a line to prepend the registry with a `/` to each `inputs.Tags`. This way it should build/push for the given registry.