### PR TITLE
Update build.go

### DIFF
--- a/build.go
+++ b/build.go
@@ -1,11 +1,15 @@
 package main
 
+import  (
+	"strings"
+)
+
 func build(cmd Commander, inputs Inputs) error {
 	args := []string{
 		"build",
 		"--file", inputs.Dockerfile,
 	}
-
+	args = strings.toLower(args)
 	if inputs.Cache != "" {
 		args = append(args, "--from-cache", inputs.Cache)
 	}


### PR DESCRIPTION
image name and repository must be in lower case, as docker cannot build images with upper case letters and throws the following error:

invalid argument "CapitalLetter/ImageName:0.0.13" for "-t, --tag" flag: invalid reference format: repository name must be lowercase
See 'docker build --help'.
failed to build image: exit status 125