### PR TITLE
Fix option name for cache

### DIFF
--- a/build.go
+++ b/build.go
@@ -7,7 +7,7 @@ func build(cmd Commander, inputs Inputs) error {
 	}
 
 	if inputs.Cache != "" {
-		args = append(args, "--from-cache", inputs.Cache)
+		args = append(args, "--cache-from", inputs.Cache)
 	}
 
 	for _, v := range inputs.BuildArgs {

--- a/build_test.go
+++ b/build_test.go
@@ -45,7 +45,7 @@ func Test_build(t *testing.T) {
 				Cache:      "cached_image:latest",
 			},
 			expect: commandArguments{"docker", []string{"build", "--file", "Dockerfile",
-				"--from-cache", "cached_image:latest",
+				"--cache-from", "cached_image:latest",
 				"."}},
 		},
 


### PR DESCRIPTION
```
Flag shorthand -h has been deprecated, please use --help

Usage:	docker build [OPTIONS] PATH | URL | -

Build an image from a Dockerfile

Options:
      --add-host list           Add a custom host-to-IP mapping (host:ip)
      --build-arg list          Set build-time variables
      --cache-from strings      Images to consider as cache sources
      --cgroup-parent string    Optional parent cgroup for the container
      --compress                Compress the build context using gzip
```