### PR TITLE
Fix error when pushing to ghcr.io for organizations containing uppercase letters

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       run: bash <(curl -s https://codecov.io/bash) -f coverage.out
 
     - name: Publish
-      uses: hartmutobendorf/publish-docker-action@v1.0.0
+      uses: hartmutobendorf/publish-docker-action@v0.0.1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.16
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.16
 
     - name: Download dependencies
       run: go mod vendor

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       run: bash <(curl -s https://codecov.io/bash) -f coverage.out
 
     - name: Publish
-      uses: jerray/publish-docker-action@v1.0.0
+      uses: hartmutobendorf/publish-docker-action@v1.0.0
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine as builder
+FROM golang:1.16-alpine as builder
 
 WORKDIR /src
 COPY . /src

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ tag and push to docker default registry (docker.io). Repository name is your Git
 name by default.
 
 ```yaml
-- uses: hartmutobendorf/publish-docker-action@main
+- uses: hartmutobendorf/publish-docker-action@master
   with:
     username: ${{ secrets.DOCKER_USERNAME }}
     password: ${{ secrets.DOCKER_PASSWORD }}
@@ -30,7 +30,7 @@ You can set docker registry with `registry` argument. Change docker repository n
 For example:
 
 ```yaml
-- uses: hartmutobendorf/publish-docker-action@main
+- uses: hartmutobendorf/publish-docker-action@master
   with:
     username: ${{ secrets.DOCKER_USERNAME }}
     password: ${{ secrets.DOCKER_PASSWORD }}
@@ -47,7 +47,7 @@ This will build and push the tag `docker.pkg.github.com/jerray/publish-docker-ac
 You can use static tag list by providing `tags` argument. Concat multiple tag names with commas.
 
 ```yaml
-- uses: hartmutobendorf/publish-docker-action@main
+- uses: hartmutobendorf/publish-docker-action@master
   with:
     username: ${{ secrets.DOCKER_USERNAME }}
     password: ${{ secrets.DOCKER_PASSWORD }}
@@ -67,7 +67,7 @@ This example builds the image, creates three tags, and pushes all of them to the
 Set `with.auto_tag: true` to allow action generate docker image tags automatically.
 
 ```yaml
-- uses: hartmutobendorf/publish-docker-action@main
+- uses: hartmutobendorf/publish-docker-action@master
   with:
     username: ${{ secrets.DOCKER_USERNAME }}
     password: ${{ secrets.DOCKER_PASSWORD }}
@@ -100,7 +100,7 @@ Additionally, there's an output value `tag` you can use [in your next steps](htt
 
 ```yaml
 - id: build
-  uses: hartmutobendorf/publish-docker-action@main
+  uses: hartmutobendorf/publish-docker-action@master
   with:
     username: ${{ secrets.DOCKER_USERNAME }}
     password: ${{ secrets.DOCKER_PASSWORD }}
@@ -124,7 +124,7 @@ Provide `with.cache` argument to build from cache.
 Use `with.build_args` to provide docker build-time variables. Multiple variables must be separated by comma. 
 
 ```yaml
-- uses: hartmutobendorf/publish-docker-action@main
+- uses: hartmutobendorf/publish-docker-action@master
   with:
     username: ${{ secrets.DOCKER_USERNAME }}
     password: ${{ secrets.DOCKER_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Publish Docker Action
 
-Based on https://github.com/jerray/publish-docker-action, this fixes the problem of building docker and pushing docker images.
+Based on https://github.com/jerray/publish-docker-action, this fixes the problem of building docker and pushing docker images, documented in https://github.com/jerray/publish-docker-action/pull/18.
 
 [![GitHub Action](https://github.com/jerray/publish-docker-action/workflows/Main/badge.svg)](https://github.com/jerray/publish-docker-action/actions?workflow=Main)
 [![codecov](https://codecov.io/gh/jerray/publish-docker-action/branch/master/graph/badge.svg)](https://codecov.io/gh/jerray/publish-docker-action)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ tag and push to docker default registry (docker.io). Repository name is your Git
 name by default.
 
 ```yaml
-- uses: jerray/publish-docker-action@master
+- uses: hartmutobendorf/publish-docker-action@main
   with:
     username: ${{ secrets.DOCKER_USERNAME }}
     password: ${{ secrets.DOCKER_PASSWORD }}
@@ -30,12 +30,12 @@ You can set docker registry with `registry` argument. Change docker repository n
 For example:
 
 ```yaml
-- uses: jerray/publish-docker-action@master
+- uses: hartmutobendorf/publish-docker-action@main
   with:
     username: ${{ secrets.DOCKER_USERNAME }}
     password: ${{ secrets.DOCKER_PASSWORD }}
     registry: docker.pkg.github.com
-    repository: jerray/publish-docker-action
+    repository: Chainstep/publish-docker-action
 ```
 
 This will build and push the tag `docker.pkg.github.com/jerray/publish-docker-action:latest`.
@@ -47,12 +47,12 @@ This will build and push the tag `docker.pkg.github.com/jerray/publish-docker-ac
 You can use static tag list by providing `tags` argument. Concat multiple tag names with commas.
 
 ```yaml
-- uses: jerray/publish-docker-action@master
+- uses: hartmutobendorf/publish-docker-action@main
   with:
     username: ${{ secrets.DOCKER_USERNAME }}
     password: ${{ secrets.DOCKER_PASSWORD }}
     registry: docker.pkg.github.com
-    repository: jerray/publish-docker-action
+    repository: Chainstep/publish-docker-action
     tags: latest,newest,master
 ```
 
@@ -67,12 +67,12 @@ This example builds the image, creates three tags, and pushes all of them to the
 Set `with.auto_tag: true` to allow action generate docker image tags automatically.
 
 ```yaml
-- uses: jerray/publish-docker-action@master
+- uses: hartmutobendorf/publish-docker-action@main
   with:
     username: ${{ secrets.DOCKER_USERNAME }}
     password: ${{ secrets.DOCKER_PASSWORD }}
     registry: docker.pkg.github.com
-    repository: jerray/publish-docker-action
+    repository: Chainstep/publish-docker-action
     auto_tag: true
 ```
 
@@ -100,12 +100,12 @@ Additionally, there's an output value `tag` you can use [in your next steps](htt
 
 ```yaml
 - id: build
-  uses: jerray/publish-docker-action@master
+  uses: hartmutobendorf/publish-docker-action@main
   with:
     username: ${{ secrets.DOCKER_USERNAME }}
     password: ${{ secrets.DOCKER_PASSWORD }}
     registry: docker.pkg.github.com
-    repository: jerray/publish-docker-action
+    repository: Chainstep/publish-docker-action
     auto_tag: true
 
 - id: deploy
@@ -124,12 +124,12 @@ Provide `with.cache` argument to build from cache.
 Use `with.build_args` to provide docker build-time variables. Multiple variables must be separated by comma. 
 
 ```yaml
-- uses: jerray/publish-docker-action@master
+- uses: hartmutobendorf/publish-docker-action@main
   with:
     username: ${{ secrets.DOCKER_USERNAME }}
     password: ${{ secrets.DOCKER_PASSWORD }}
     registry: docker.pkg.github.com
-    repository: jerray/publish-docker-action
+    repository: Chainstep/publish-docker-action
     build_args: HTTP_PROXY=http://127.0.0.1,USER=nginx
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Publish Docker Action
 
+Based on https://github.com/jerray/publish-docker-action, this fixes the problem of building docker and pushing docker images.
+
 [![GitHub Action](https://github.com/jerray/publish-docker-action/workflows/Main/badge.svg)](https://github.com/jerray/publish-docker-action/actions?workflow=Main)
 [![codecov](https://codecov.io/gh/jerray/publish-docker-action/branch/master/graph/badge.svg)](https://codecov.io/gh/jerray/publish-docker-action)
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/jerray/publish-docker-action?logo=github)](https://github.com/jerray/publish-docker-action/releases)

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'Publish Docker Action'
 description: 'Build, tag and publish docker image to your docker registry'
-author: 'jerray'
+author: 'hartmutobendorf, jerray'
 inputs:
   username:
     description: 'Username used to login docker registry'
@@ -48,7 +48,7 @@ outputs:
     description: 'Tag name produced by activating the auto_tag option'
 runs:
   using: 'docker'
-  image: 'docker://jerray/publish-docker-action:1.0.5'
+  image: 'docker://hartmutobendorf/publish-docker-action:1.0.0'
 branding:
   icon: 'anchor'
   color: 'blue'

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/jerray/publish-docker-action
 
-go 1.13
+go 1.16
 
 require github.com/caarlos0/env/v6 v6.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jerray/publish-docker-action
+module github.com/Chainstep/publish-docker-action
 
 go 1.16
 

--- a/helper.go
+++ b/helper.go
@@ -14,7 +14,7 @@ const (
 
 func resolveInputs(github GitHub, inputs *Inputs) error {
 	if inputs.Repository == "" {
-		inputs.Repository = strings.ToLower(github.Repository)
+		inputs.Repository = github.Repository
 	}
 
 	if inputs.Registry != "" && !strings.HasPrefix(inputs.Repository, inputs.Registry) {
@@ -30,7 +30,7 @@ func resolveInputs(github GitHub, inputs *Inputs) error {
 	resolveAutoTag(typ, name, inputs)
 
 	for i, t := range inputs.Tags {
-		inputs.Tags[i] = strings.Join([]string{inputs.Repository, t}, ":")
+		inputs.Tags[i] = strings.Join([]string{strings.ToLower(inputs.Repository), t}, ":")
 	}
 
 	return nil

--- a/helper.go
+++ b/helper.go
@@ -14,7 +14,7 @@ const (
 
 func resolveInputs(github GitHub, inputs *Inputs) error {
 	if inputs.Repository == "" {
-		inputs.Repository = github.Repository
+		inputs.Repository = strings.ToLower(github.Repository)
 	}
 
 	if inputs.Registry != "" && !strings.HasPrefix(inputs.Repository, inputs.Registry) {

--- a/helper_test.go
+++ b/helper_test.go
@@ -83,6 +83,20 @@ func Test_resolveInputs(t *testing.T) {
 			tags:       []string{},
 			repository: "username/repo",
 		},
+		{
+			github: GitHub{
+				Repository: "Organization/username/repo",
+				Commit:     "45ba489c4f97b5f854ebaba6454b51fa",
+				Ref:        "refs/pull/master",
+			},
+			inputs: &Inputs{
+				Tags:             []string{},
+				AllowPullRequest: false,
+			},
+			hasError:   true,
+			tags:       []string{},
+			repository: "organization/username/repo",
+		},
 	}
 	for _, c := range cases {
 		err := resolveInputs(c.github, c.inputs)

--- a/helper_test.go
+++ b/helper_test.go
@@ -83,20 +83,6 @@ func Test_resolveInputs(t *testing.T) {
 			tags:       []string{},
 			repository: "username/repo",
 		},
-		{
-			github: GitHub{
-				Repository: "Organization/username/repo",
-				Commit:     "45ba489c4f97b5f854ebaba6454b51fa",
-				Ref:        "refs/pull/master",
-			},
-			inputs: &Inputs{
-				Tags:             []string{},
-				AllowPullRequest: false,
-			},
-			hasError:   true,
-			tags:       []string{},
-			repository: "organization/username/repo",
-		},
 	}
 	for _, c := range cases {
 		err := resolveInputs(c.github, c.inputs)


### PR DESCRIPTION
Fix this error:
invalid argument "ghcr.io/Organization/****:main" for "-t, --tag" flag: invalid reference format: repository name must be lowercase

* change the tag format to use only lowercase letters for the repository string
* pushed Go version